### PR TITLE
New rules for preparing_image and fsm.error_kind

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -39,6 +39,26 @@ Samplers:
               Value: flyd
           Drop: false
           SampleRate: 100
+
+        - Name: machine.preparing_image slow keep all
+          Conditions:
+            - Field: name
+              Operator: =
+              Value: machine.preparing_image
+            - Field: duration_ms
+              Operator: '>='
+              Value: 5_000
+              Datatype: float
+          Drop: false
+          SampleRate: 1
+
+        - Name: fsm.error exists keep all
+          Conditions:
+            - Field: fsm.error_kind
+              Operator: exists
+          Drop: false
+          SampleRate: 1
+
         - Name: keep fsm actions
           Conditions:
             - Field: fsm.action
@@ -104,25 +124,6 @@ Samplers:
                 - rpc.service
                 - rpc.method
                 - status_code
-
-        - Name: machine.preparing_image slow keep all
-          Conditions:
-            - Field: name
-              Operator: =
-              Value: machine.preparing_image
-            - Field: duration_ms
-              Operator: '>='
-              Value: 5_000
-              Datatype: float
-          Drop: false
-          SampleRate: 1
-
-        - Name: fsm.error exists keep all
-          Conditions:
-            - Field: fsm.error_kind
-              Operator: exists
-          Drop: false
-          SampleRate: 1
 
         - Name: default
           SampleRate: 70

--- a/rules.yaml
+++ b/rules.yaml
@@ -104,5 +104,25 @@ Samplers:
                 - rpc.service
                 - rpc.method
                 - status_code
+
+        - Name: machine.preparing_image slow keep all
+          Conditions:
+            - Field: name
+              Operator: =
+              Value: machine.preparing_image
+            - Field: duration_ms
+              Operator: '>='
+              Value: 5_000
+              Datatype: float
+          Drop: false
+          SampleRate: 1
+
+        - Name: fsm.error exists keep all
+          Conditions:
+            - Field: fsm.error_kind
+              Operator: exists
+          Drop: false
+          SampleRate: 1
+
         - Name: default
           SampleRate: 70


### PR DESCRIPTION
Save all preparing_image traces >5s. I estimate that's around 1million spans per day, maybe. We can always increase the threshold, especially once we get past the current investigation. https://docs.google.com/spreadsheets/d/1LyknKiodAczWXYIGPIy_MD7eNfHyftFaz7wgZCNJFH0/edit#gid=0

Save all traces where fsm.error_kind exists. I figure errors are more likely to be interesting to review as traces. I'm not sure how to estimate this... we had ~60k traces in the last day where fsm.error_kind existed, which seems low enough to ingest everything.
